### PR TITLE
Bugfix/fix low activity watermark

### DIFF
--- a/gadgets/hallmonitor/spam_feed.go
+++ b/gadgets/hallmonitor/spam_feed.go
@@ -184,7 +184,14 @@ func userActivityScore(uid string) (int, error) {
 		return 0, nil
 	}
 
-	searchQuery := fmt.Sprintf("after:2021/12/01 from:@%s", uid)
+	// this is a workaround until we can determine what is causing UIDs from non-admin
+	// accounts from not registering for search.message requests
+	u, err := getUserInfo(uid, api)
+	if err != nil {
+		return 0, err
+	}
+
+	searchQuery := fmt.Sprintf("after:2021/12/01 from:@%s", u.Name)
 
 	results, err := api.SearchMessages(searchQuery, slack.NewSearchParameters())
 	if err != nil {
@@ -243,4 +250,10 @@ func addDebugResponse(removed bool, score int, reasons []string, msg slack.Messa
 		_, _, err = conversations.ThreadedReplyToMsg(msg, debugResponse, api)
 	}
 	return err
+}
+
+func getUserInfo(uid string, api *slack.Client) (*slack.User, error) {
+	user, err := api.GetUserInfo(uid)
+
+	return user, err
 }


### PR DESCRIPTION
fixes #3 

For whatever reason non-admins do not register on slack's `search.messages` api call when the query is looking for UID, but they return perfectly fine when querying by username. I split getUserInfo into its own method in case we wanted to move it elsewhere later on.

Did not add any tests since this is using third party and private methods, but the existing tests look good:
```
$ go test ./...
zsh: correct './...' to './..' [nyae]? n

?       github.com/xortim/penny [no test files]
?       github.com/xortim/penny/cmd     [no test files]
?       github.com/xortim/penny/conf    [no test files]
?       github.com/xortim/penny/gadgets/hallmonitor     [no test files]
ok      github.com/xortim/penny/pkg/conversations       0.305s
ok      github.com/xortim/penny/pkg/parsers     0.391s
```