### PR TITLE
better query as provided by slack support

### DIFF
--- a/gadgets/hallmonitor/spam_feed.go
+++ b/gadgets/hallmonitor/spam_feed.go
@@ -184,14 +184,7 @@ func userActivityScore(uid string) (int, error) {
 		return 0, nil
 	}
 
-	// this is a workaround until we can determine what is causing UIDs from non-admin
-	// accounts from not registering for search.message requests
-	u, err := getUserInfo(uid, api)
-	if err != nil {
-		return 0, err
-	}
-
-	searchQuery := fmt.Sprintf("after:2021/12/01 from:@%s", u.Name)
+	searchQuery := fmt.Sprintf("after:2021/12/01 from:<@%s>", uid)
 
 	results, err := api.SearchMessages(searchQuery, slack.NewSearchParameters())
 	if err != nil {
@@ -250,10 +243,4 @@ func addDebugResponse(removed bool, score int, reasons []string, msg slack.Messa
 		_, _, err = conversations.ThreadedReplyToMsg(msg, debugResponse, api)
 	}
 	return err
-}
-
-func getUserInfo(uid string, api *slack.Client) (*slack.User, error) {
-	user, err := api.GetUserInfo(uid)
-
-	return user, err
 }


### PR DESCRIPTION
From slack support, they were muuuuch faster to respond than I anticipated:

> Hi Devin,
> Thanks for your patience here.
> Yeah, I can reproduce what you're seeing too. I have passed this on to our engineering team for further investigation, but in the meantime, if you simply wrap the ID with angle brackets in your call, then it should work:
> `"query": "in:<@U123456>"`
> In any case, I will let you know when I have more information.
> Kind regards,
> Richard

Confirmed this works in my local environment. Saves us one call to the slack API.

Simple refactor, does not change the expected behavior from #28 