### PR TITLE
goreleaser setup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+project_name: penny
+
+builds:
+  - main: .
+    binary: "{{ .Os }}-{{ .Arch }}/penny"
+    no_unique_dist_dir: true
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/xortim/penny/conf.GitVersion={{.Version}}
+    hooks:
+      post:
+        - cmd: ln -sf {{ .Os }}-{{ .Arch }}/penny dist/penny
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,19 @@ tools: ## Install tools needed for development
 	@go get -u golang.org/x/lint/golint
 
 ###############
+##@ Release
+
+.PHONY: snapshot
+snapshot: ## Build a snapshot release locally (no publish)
+	@$(MAKE) --no-print-directory log-$@
+	goreleaser release --snapshot --clean
+
+.PHONY: release
+release: ## Create a release with goreleaser
+	@$(MAKE) --no-print-directory log-$@
+	goreleaser release --clean
+
+###############
 ##@ Database
 .PHONY: start-db
 start-db: ## Start maria db - export DB_ROOT_PASS and DB_PASS to set credentials

--- a/conf/version.go
+++ b/conf/version.go
@@ -4,6 +4,6 @@ var (
 	// Executable is overridden by Makefile
 	Executable = "penny"
 
-	// GitVersion is overridden by Makefile
-	GitVersion = "NoSet"
+	// GitVersion is overridden at build time via ldflags
+	GitVersion = "dev"
 )


### PR DESCRIPTION
## Summary
- Add goreleaser v2 config for cross-platform release builds with Make targets

## Test plan
- [x] Run `make test` to verify all tests pass
- [x] Run `make snapshot` to verify goreleaser builds correctly